### PR TITLE
Boss Pattern + AnimNotify

### DIFF
--- a/Source/CatheralBattle/Private/ANS_ParryWindow.cpp
+++ b/Source/CatheralBattle/Private/ANS_ParryWindow.cpp
@@ -1,0 +1,30 @@
+﻿#include "ANS_ParryWindow.h"
+#include "Boss_Sevarog.h"
+#include "PlayerCharacter.h"
+#include "Kismet/GameplayStatics.h"
+
+void UANS_ParryWindow::NotifyBegin(USkeletalMeshComponent* MeshComp,
+    UAnimSequenceBase* Animation,
+    float TotalDuration,
+    const FAnimNotifyEventReference& EventReference)
+{
+    if (!MeshComp) return;
+    if (ABoss_Sevarog* Boss = Cast<ABoss_Sevarog>(MeshComp->GetOwner()))
+    {
+        if (APawn* P = UGameplayStatics::GetPlayerPawn(Boss, 0))
+        {
+            if (APlayerCharacter* Target = Cast<APlayerCharacter>(P))
+            {
+                // 창 열기: 이 구간(Duration) 동안만 성공
+                Boss->OnBossArmParry.Broadcast(Target, HitIndex, TotalDuration);
+            }
+        }
+    }
+}
+
+void UANS_ParryWindow::NotifyEnd(USkeletalMeshComponent* MeshComp,
+    UAnimSequenceBase* Animation,
+    const FAnimNotifyEventReference& EventReference)
+{
+    // 필요 시 여기서 창 강제 종료 로직 추가 가능(현재는 Duration 타이머로 닫힘)
+}

--- a/Source/CatheralBattle/Private/ANS_ParryWindow.h
+++ b/Source/CatheralBattle/Private/ANS_ParryWindow.h
@@ -1,0 +1,21 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotifyState.h"
+#include "ANS_ParryWindow.generated.h"
+
+UCLASS()
+class CATHERALBATTLE_API UANS_ParryWindow : public UAnimNotifyState
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite) int32 HitIndex = 0;
+
+    virtual void NotifyBegin(USkeletalMeshComponent* MeshComp,
+        UAnimSequenceBase* Animation,
+        float TotalDuration,
+        const FAnimNotifyEventReference& EventReference) override;
+
+    virtual void NotifyEnd(USkeletalMeshComponent* MeshComp,
+        UAnimSequenceBase* Animation,
+        const FAnimNotifyEventReference& EventReference) override;
+};

--- a/Source/CatheralBattle/Private/AN_BossHit.cpp
+++ b/Source/CatheralBattle/Private/AN_BossHit.cpp
@@ -1,0 +1,21 @@
+﻿#include "AN_BossHit.h"
+#include "Boss_Sevarog.h"
+#include "PlayerCharacter.h"
+#include "Kismet/GameplayStatics.h"
+
+void UAN_BossHit::Notify(USkeletalMeshComponent* MeshComp,
+    UAnimSequenceBase* Animation,
+    const FAnimNotifyEventReference& EventReference)
+{
+    if (!MeshComp) return;
+    if (ABoss_Sevarog* Boss = Cast<ABoss_Sevarog>(MeshComp->GetOwner()))
+    {
+        if (APawn* P = UGameplayStatics::GetPlayerPawn(Boss, 0))
+        {
+            if (APlayerCharacter* Target = Cast<APlayerCharacter>(P))
+            {
+                Boss->ApplyHitIfNotParried(Target, HitIndex, DamageMultiplier);
+            }
+        }
+    }
+}

--- a/Source/CatheralBattle/Private/AN_PatternBegin.cpp
+++ b/Source/CatheralBattle/Private/AN_PatternBegin.cpp
@@ -1,0 +1,21 @@
+﻿#include "AN_PatternBegin.h"
+#include "Boss_Sevarog.h"
+#include "PlayerCharacter.h"
+#include "Kismet/GameplayStatics.h"
+
+void UAN_PatternBegin::Notify(USkeletalMeshComponent* MeshComp,
+    UAnimSequenceBase* Animation,
+    const FAnimNotifyEventReference& EventReference)
+{
+    if (!MeshComp) return;
+    if (ABoss_Sevarog* Boss = Cast<ABoss_Sevarog>(MeshComp->GetOwner()))
+    {
+        if (APawn* P = UGameplayStatics::GetPlayerPawn(Boss, 0))
+        {
+            if (APlayerCharacter* Target = Cast<APlayerCharacter>(P))
+            {
+                Boss->NotifyPatternBegin(Target, ExpectedHits);
+            }
+        }
+    }
+}

--- a/Source/CatheralBattle/Private/AN_PatternBegin.h
+++ b/Source/CatheralBattle/Private/AN_PatternBegin.h
@@ -1,0 +1,16 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "AN_PatternBegin.generated.h"
+
+UCLASS()
+class CATHERALBATTLE_API UAN_PatternBegin : public UAnimNotify
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite) int32 ExpectedHits = 0;
+
+    virtual void Notify(USkeletalMeshComponent* MeshComp,
+        UAnimSequenceBase* Animation,
+        const FAnimNotifyEventReference& EventReference) override;
+};

--- a/Source/CatheralBattle/Private/AN_PatternEnd.cpp
+++ b/Source/CatheralBattle/Private/AN_PatternEnd.cpp
@@ -1,0 +1,13 @@
+﻿#include "AN_PatternEnd.h"
+#include "Boss_Sevarog.h"
+
+void UAN_PatternEnd::Notify(USkeletalMeshComponent* MeshComp,
+    UAnimSequenceBase* Animation,
+    const FAnimNotifyEventReference& EventReference)
+{
+    if (!MeshComp) return;
+    if (ABoss_Sevarog* Boss = Cast<ABoss_Sevarog>(MeshComp->GetOwner()))
+    {
+        Boss->NotifyPatternEnd();
+    }
+}

--- a/Source/CatheralBattle/Private/BattleManager.cpp
+++ b/Source/CatheralBattle/Private/BattleManager.cpp
@@ -1,0 +1,141 @@
+﻿#include "BattleManager.h"
+#include "Kismet/GameplayStatics.h"
+#include "TimerManager.h"
+#include "PlayerCharacter.h"
+#include "Boss_Sevarog.h"
+#include "ParryInputProxy.h"
+#include "Animation/AnimMontage.h"
+
+ABattleManager::ABattleManager()
+{
+	PrimaryActorTick.bCanEverTick = false;
+}
+
+void ABattleManager::BeginPlay()
+{
+	Super::BeginPlay();
+	if (!ParryProxy) { TryAutoWireProxy(); }
+	if (bAutoStart) { StartBattle(); }
+}
+
+void ABattleManager::Initialize(APlayerCharacter* InPlayer, ABoss_Sevarog* InBoss, AParryInputProxy* InProxy)
+{
+	PlayerRef = InPlayer;
+	BossRef = InBoss;
+	if (InProxy) { ParryProxy = InProxy; }
+	else if (!ParryProxy) { TryAutoWireProxy(); }
+
+	// 플레이어 사망 감지
+	if (PlayerRef)
+	{
+		PlayerRef->OnHpChanged.AddDynamic(this, &ABattleManager::OnPlayerHpChanged);
+	}
+	// 보스 패턴 종료 감지
+	if (BossRef)
+	{
+		BossRef->OnPatternFinished.AddDynamic(this, &ABattleManager::OnBossPatternFinished);
+	}
+}
+
+void ABattleManager::StartBattle()
+{
+	if (bRunning || !PlayerRef || !BossRef) return;
+	bRunning = true;
+	LastPatternIdx = -1;
+	EnterPlayerTurn();
+}
+
+void ABattleManager::EndBattle()
+{
+	if (!bRunning) return;
+	bRunning = false;
+
+	SetParryEnabled(false);
+
+	if (PlayerRef) { PlayerRef->OnHpChanged.RemoveDynamic(this, &ABattleManager::OnPlayerHpChanged); }
+	if (BossRef) { BossRef->OnPatternFinished.RemoveDynamic(this, &ABattleManager::OnBossPatternFinished); }
+}
+
+void ABattleManager::NotifyPlayerTurnDone()
+{
+	if (!bRunning) return;
+	CheckEnd();
+	if (!bRunning) return;
+	EnterBossTurn();
+}
+
+void ABattleManager::EnterPlayerTurn()
+{
+	CurrentTurn = ETurn::Player;
+	SetParryEnabled(false); // 보스턴 아님 → 패링 비활성
+	// 플레이어 커맨드 입력/UI는 게임 쪽에서 처리 후 NotifyPlayerTurnDone 호출!
+}
+
+void ABattleManager::EnterBossTurn()
+{
+	CurrentTurn = ETurn::Boss;
+	SetParryEnabled(true); // 보스턴 → 패링 활성
+
+	// 몽타주 선택
+	UAnimMontage* Chosen = nullptr;
+	if (BossPatternMontages.Num() > 0)
+	{
+		const int32 Idx = PickMontageIndex();
+		Chosen = BossPatternMontages[Idx];
+		LastPatternIdx = Idx;
+	}
+	// 패턴 재생(Notify들이 패턴 Begin/Window/Hit/End를 처리)
+	BossRef->PlayPatternMontage(Chosen, PlayerRef);
+}
+
+int32 ABattleManager::PickMontageIndex() const
+{
+	if (BossPatternMontages.Num() <= 1 || !bDisallowRepeat || LastPatternIdx < 0)
+	{
+		return FMath::Clamp(FMath::RandRange(0, BossPatternMontages.Num() - 1), 0, BossPatternMontages.Num() - 1);
+	}
+	int32 Idx;
+	do { Idx = FMath::RandRange(0, BossPatternMontages.Num() - 1); } while (Idx == LastPatternIdx);
+	return Idx;
+}
+
+void ABattleManager::SetParryEnabled(bool bEnable)
+{
+	if (!ParryProxy)
+	{
+		TryAutoWireProxy();
+		if (!ParryProxy) return;
+	}
+	if (APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0))
+	{
+		if (bEnable) { ParryProxy->EnableInput(PC); }
+		else { ParryProxy->DisableInput(PC); }
+	}
+}
+
+void ABattleManager::TryAutoWireProxy()
+{
+	TArray<AActor*> Found;
+	UGameplayStatics::GetAllActorsOfClass(GetWorld(), AParryInputProxy::StaticClass(), Found);
+	if (Found.Num() > 0) { ParryProxy = Cast<AParryInputProxy>(Found[0]); }
+}
+
+void ABattleManager::OnPlayerHpChanged(float NewHp, float MaxHp)
+{
+	if (NewHp <= 0.f) { EndBattle(); }
+}
+
+void ABattleManager::OnBossPatternFinished()
+{
+	if (!bRunning) return;
+	CheckEnd();
+	if (!bRunning) return;
+	EnterPlayerTurn();
+}
+
+void ABattleManager::CheckEnd()
+{
+	if (!PlayerRef || !BossRef) { EndBattle(); return; }
+	if (PlayerRef->IsDead()) { EndBattle(); return; }
+	if (BossRef->Hp <= 0.f) { EndBattle(); return; }
+}

--- a/Source/CatheralBattle/Private/BattleManager.h
+++ b/Source/CatheralBattle/Private/BattleManager.h
@@ -1,0 +1,74 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "BattleManager.generated.h"
+
+class APlayerCharacter;
+class ABoss_Sevarog;
+class AParryInputProxy;
+class UAnimMontage;
+
+UENUM(BlueprintType)
+enum class ETurn : uint8 { Player, Boss };
+
+/** 턴제 매니저 */
+UCLASS()
+class CATHERALBATTLE_API ABattleManager : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	ABattleManager();
+
+	/** 보스 패턴 몽타주 리스트(랜덤 선택, 직전 반복 금지 옵션) */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Battle|Setup")
+	TArray<UAnimMontage*> BossPatternMontages;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Battle|Setup")
+	bool bDisallowRepeat = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Battle|Setup")
+	bool bAutoStart = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Battle|Setup")
+	AParryInputProxy* ParryProxy = nullptr;
+
+	/** 의존성 주입 */
+	UFUNCTION(BlueprintCallable, Category = "Battle")
+	void Initialize(APlayerCharacter* InPlayer, ABoss_Sevarog* InBoss, AParryInputProxy* InProxy = nullptr);
+
+	/** 시작/종료 */
+	UFUNCTION(BlueprintCallable, Category = "Battle") void StartBattle();
+	UFUNCTION(BlueprintCallable, Category = "Battle") void EndBattle();
+
+	/** 플레이어 턴 종료 콜백(UI에서 호출) */
+	UFUNCTION(BlueprintCallable, Category = "Battle") void NotifyPlayerTurnDone();
+
+	UFUNCTION(BlueprintPure, Category = "Battle") ETurn GetCurrentTurn() const { return CurrentTurn; }
+
+protected:
+	virtual void BeginPlay() override;
+
+private:
+	UPROPERTY() APlayerCharacter* PlayerRef = nullptr;
+	UPROPERTY() ABoss_Sevarog* BossRef = nullptr;
+
+	ETurn CurrentTurn = ETurn::Player;
+	bool  bRunning = false;
+	int32 LastPatternIdx = -1;
+
+	/** 턴 전환 */
+	void EnterPlayerTurn();
+	void EnterBossTurn();
+
+	/** 유틸 */
+	int32 PickMontageIndex() const;
+	void  SetParryEnabled(bool bEnable);
+	void  TryAutoWireProxy();
+
+	/** 승패 및 이벤트 */
+	void  CheckEnd();
+
+	UFUNCTION() void OnPlayerHpChanged(float NewHp, float MaxHp);
+	UFUNCTION() void OnBossPatternFinished();
+};

--- a/Source/CatheralBattle/Private/Boss_Sevarog.cpp
+++ b/Source/CatheralBattle/Private/Boss_Sevarog.cpp
@@ -1,7 +1,5 @@
 ﻿#include "Boss_Sevarog.h"
-#include "TimerManager.h"
-#include "Engine/World.h"
-#include "Kismet/GameplayStatics.h"
+#include "Animation/AnimInstance.h"
 #include "PlayerCharacter.h"
 
 ABoss_Sevarog::ABoss_Sevarog()
@@ -11,83 +9,61 @@ ABoss_Sevarog::ABoss_Sevarog()
 	AtkPoint = 10.f;
 }
 
-void ABoss_Sevarog::PlayCurrentPattern(APlayerCharacter* Target)
+void ABoss_Sevarog::PlayPatternMontage(UAnimMontage* Montage, APlayerCharacter* Target)
 {
-	if (!Target || CurrentPattern.Num() <= 0) return;
-
-	// 진행 정리
+	CurrentTarget = Target;
 	SucceededHits.Empty();
-	for (FTimerHandle& H : PendingTimers) { GetWorldTimerManager().ClearTimer(H); }
-	PendingTimers.Reset();
-
-	// 애니/카메라 연출은 BP에서 재생
-	// 타이밍 예약: Arm(Offset-Window) → Resolve(Offset)
-	for (int32 i = 0; i < CurrentPattern.Num(); ++i)
+	if (Montage && GetMesh())
 	{
-		const FBossHitSpec& Hit = CurrentPattern[i];
-
-		// Arm: 히트 직전 창 열기 알림
-		const float ArmTime = FMath::Max(0.f, Hit.QTEOffset - Hit.QTEWindow);
-		FTimerHandle HArm;
-		GetWorldTimerManager().SetTimer(
-			HArm,
-			FTimerDelegate::CreateUObject(this, &ABoss_Sevarog::FireHitCue, Target, i),
-			ArmTime, false
-		);
-		PendingTimers.Add(HArm);
-
-		// Resolve: 실제 히트 판정
-		FTimerHandle HResolve;
-		GetWorldTimerManager().SetTimer(
-			HResolve,
-			FTimerDelegate::CreateUObject(this, &ABoss_Sevarog::ResolveHit, Target, i),
-			Hit.QTEOffset, false
-		);
-		PendingTimers.Add(HResolve);
+		if (UAnimInstance* Anim = GetMesh()->GetAnimInstance())
+		{
+			Anim->Montage_Play(Montage, 1.0f);
+		}
 	}
 }
 
-void ABoss_Sevarog::FireHitCue(APlayerCharacter* Target, int32 HitIndex)
+void ABoss_Sevarog::NotifyPatternBegin(APlayerCharacter* Target, int32 InExpectedHits)
 {
-	if (!Target || !CurrentPattern.IsValidIndex(HitIndex)) return;
-
-	// 항상 패링 가능, Arm은 정답 타이밍만 알림.
-	// 플레이어는 이 이벤트를 받아 자신의 패링창/버퍼를 활성화
-	OnBossArmParry.Broadcast(Target, HitIndex, CurrentPattern[HitIndex].QTEWindow);
+	CurrentTarget = Target;
+	ExpectedHits = FMath::Max(0, InExpectedHits);
+	SucceededHits.Empty();
 }
 
-void ABoss_Sevarog::ResolveHit(APlayerCharacter* Target, int32 HitIndex)
+void ABoss_Sevarog::NotifyPatternEnd()
 {
-	if (!Target || !CurrentPattern.IsValidIndex(HitIndex)) return;
-
-	// 성공했으면 피해 0
-	if (SucceededHits.Contains(HitIndex))
+	// 전 히트 성공 → Ult +10
+	if (CurrentTarget.IsValid() && ExpectedHits > 0 && SucceededHits.Num() == ExpectedHits)
 	{
-		return;
+		CurrentTarget.Get()->AddUltGauge(10.f);
 	}
+	OnPatternFinished.Broadcast();
 
-	// 실패 히트만 데미지 적용
-	const FBossHitSpec& Hit = CurrentPattern[HitIndex];
-	const float Damage = AtkPoint * Hit.DamageMultiplier;
-	Target->TakeDamage(Damage); // PlayerCharacter의 HP 처리/브로드캐스트 사용 
+	// 정리
+	ExpectedHits = 0;
+	SucceededHits.Empty();
+	CurrentTarget = nullptr;
+}
+
+void ABoss_Sevarog::ApplyHitIfNotParried(APlayerCharacter* Target, int32 HitIndex, float DamageMultiplier)
+{
+	if (!Target) return;
+	if (!SucceededHits.Contains(HitIndex))
+	{
+		const float Dmg = AtkPoint * FMath::Max(0.f, DamageMultiplier);
+		Target->TakeDamage(Dmg);
+	}
 }
 
 void ABoss_Sevarog::NotifyParrySuccess(APlayerCharacter* Target, int32 HitIndex)
 {
-	if (!Target || !CurrentPattern.IsValidIndex(HitIndex)) return;
+	if (!Target) return;
 
-	SucceededHits.Add(HitIndex);
-
-	// 모든 히트 성공 → Ult +10
-	if (SucceededHits.Num() == CurrentPattern.Num())
-	{
-		Target->AddUltGauge(10.f); // Ult 게이지 반영(이미 구현) 
-	}
+	SucceededHits.Add(HitIndex);           // 해당 히트 피해 0
+	Target->Stats.AP = FMath::Clamp(Target->Stats.AP + 1.f, 0.f, 6.f); // AP +1
 }
 
 void ABoss_Sevarog::ApplyDamageToBoss(float Damage)
 {
 	if (Damage <= 0.f || Hp <= 0.f) return;
 	Hp = FMath::Clamp(Hp - Damage, 0.f, MaxHp);
-	// HP 0 연출/파괴는 BP에서 처리
 }

--- a/Source/CatheralBattle/Private/Boss_Sevarog.h
+++ b/Source/CatheralBattle/Private/Boss_Sevarog.h
@@ -3,37 +3,15 @@
 #include "GameFramework/Character.h"
 #include "Boss_Sevarog.generated.h"
 
+class UAnimMontage;
 class APlayerCharacter;
 
-/** 히트별 패링/데미지 스펙 */
-USTRUCT(BlueprintType)
-struct FBossHitSpec
-{
-	GENERATED_BODY()
-
-	/** 최종피해 = AtkPoint * DamageMultiplier (예: 1.0f) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Hit")
-	float DamageMultiplier = 1.0f;
-
-	/** 모션 시작 후 이 히트가 들어가는 시점(초) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Hit")
-	float QTEOffset = 0.6f;
-
-	/** 패링 가능 시간(초). 예: 0.15f */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Hit")
-	float QTEWindow = 0.15f;
-};
-
-/** 보스가 패링창을 여는 순간을 알림(플레이어가 이 이벤트를 받아 패링창 활성) */
+/** 델리게이트 */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPatternFinished);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FOnBossArmParry, APlayerCharacter*, Target, int32, HitIndex, float, WindowSec);
 
-/**
- * Paragon Sevarog 느낌의 보스.
- * - HP 200, AtkPoint 10
- * - 다단히트 패턴: 히트 직전에 Arm → 창 내 입력 성공 시 피해 0 & AP+1
- * - 패턴의 모든 히트 성공 시 플레이어 Ult +10
- * - “항상 패링 가능” 설계 지원: Arm은 단지 ‘정답 타이밍’ 창을 알려줌
- */
+
+/** 보스(Notify 구동형) */
 UCLASS()
 class CATHERALBATTLE_API ABoss_Sevarog : public ACharacter
 {
@@ -42,48 +20,31 @@ class CATHERALBATTLE_API ABoss_Sevarog : public ACharacter
 public:
 	ABoss_Sevarog();
 
-	/** ====== 스탯 ====== */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat")
-	float MaxHp = 200.f;
+	/** 스탯 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat") float MaxHp = 200.f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat") float Hp = 200.f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat") float AtkPoint = 10.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat")
-	float Hp = 200.f;
+	/** 이벤트 */
+	UPROPERTY(BlueprintAssignable, Category = "Boss|Event") FOnBossArmParry    OnBossArmParry;
+	UPROPERTY(BlueprintAssignable, Category = "Boss|Event") FOnPatternFinished OnPatternFinished;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Stat")
-	float AtkPoint = 10.f;
-
-	/** ====== 패턴 정의(다단히트) ====== */
-	/** 이번에 재생할 패턴(히트 배열). BP에서 세팅: 2~3연타 등 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Boss|Pattern")
-	TArray<FBossHitSpec> CurrentPattern;
-
-	/** 보스 패턴 재생(애니/카메라는 BP에서; 이 함수는 Arm/판정 예약) */
+	/** 패턴 재생(몽타주) */
 	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern")
-	void PlayCurrentPattern(APlayerCharacter* Target);
+	void PlayPatternMontage(UAnimMontage* Montage, APlayerCharacter* Target);
 
-	/** 플레이어가 패링 성공 시 보스에 보고(히트별) */
-	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern")
-	void NotifyParrySuccess(APlayerCharacter* Target, int32 HitIndex);
+	/** 패턴 라이프사이클/히트 처리(Notify에서 호출) */
+	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern") void NotifyPatternBegin(APlayerCharacter* Target, int32 InExpectedHits);
+	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern") void NotifyPatternEnd();
+	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern") void ApplyHitIfNotParried(APlayerCharacter* Target, int32 HitIndex, float DamageMultiplier);
+	UFUNCTION(BlueprintCallable, Category = "Boss|Pattern") void NotifyParrySuccess(APlayerCharacter* Target, int32 HitIndex);
 
-	/** 보스 피해(플레이어 턴 등에서 호출) */
-	UFUNCTION(BlueprintCallable, Category = "Boss|Stat")
-	void ApplyDamageToBoss(float Damage);
-
-	/** 보스가 Arm을 알리는 델리게이트(플레이어가 바인딩해서 패링창 활성) */
-	UPROPERTY(BlueprintAssignable, Category = "Boss|Event")
-	FOnBossArmParry OnBossArmParry;
-
-protected:
-	/** 히트 직전: 패링창 Arm 신호 */
-	void FireHitCue(APlayerCharacter* Target, int32 HitIndex);
-
-	/** 히트 시점: 실패 히트만 피해 적용 */
-	void ResolveHit(APlayerCharacter* Target, int32 HitIndex);
+	/** 보스 피해(플레이어 턴 등) */
+	UFUNCTION(BlueprintCallable, Category = "Boss|Stat") void ApplyDamageToBoss(float Damage);
 
 private:
-	/** 이번 패턴에서 성공한 히트 인덱스 집합 */
+	/** 이번 패턴 대상/성공기록 */
+	UPROPERTY() TWeakObjectPtr<APlayerCharacter> CurrentTarget;
 	TSet<int32> SucceededHits;
-
-	/** 예약 타이머 핸들(정리용) */
-	TArray<FTimerHandle> PendingTimers;
+	int32 ExpectedHits = 0;
 };

--- a/Source/CatheralBattle/Private/ParryComponent.cpp
+++ b/Source/CatheralBattle/Private/ParryComponent.cpp
@@ -1,34 +1,149 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿#include "ParryComponent.h"
+#include "Boss_Sevarog.h"
+#include "PlayerCharacter.h"
+#include "Kismet/GameplayStatics.h"
+#include "GameFramework/Character.h"
+#include "Animation/AnimInstance.h"
+#include "TimerManager.h"
 
-
-#include "ParryComponent.h"
-
-// Sets default values for this component's properties
 UParryComponent::UParryComponent()
 {
-	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
-	// off to improve performance if you don't need them.
-	PrimaryComponentTick.bCanEverTick = true;
-
-	// ...
+	PrimaryComponentTick.bCanEverTick = false;
 }
 
-
-// Called when the game starts
 void UParryComponent::BeginPlay()
 {
 	Super::BeginPlay();
-
-	// ...
-	
+	// 보스가 나중에 스폰될 수 있으니 주기적으로 Arm 델리게이트 바인딩 시도
+	GetWorld()->GetTimerManager().SetTimer(TimerRebind, this, &UParryComponent::TryBindBoss, 0.5f, true, 0.0f);
 }
 
-
-// Called every frame
-void UParryComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+void UParryComponent::TryBindBoss()
 {
-	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
-	// ...
+	TArray<AActor*> Found;
+	UGameplayStatics::GetAllActorsOfClass(GetWorld(), ABoss_Sevarog::StaticClass(), Found);
+	for (AActor* A : Found)
+	{
+		if (ABoss_Sevarog* B = Cast<ABoss_Sevarog>(A))
+		{
+			B->OnBossArmParry.AddDynamic(this, &UParryComponent::OnBossArm);
+		}
+	}
+	if (Found.Num() > 0)
+	{
+		GetWorld()->GetTimerManager().ClearTimer(TimerRebind);
+	}
 }
 
+APlayerCharacter* UParryComponent::GetOwnerPlayer() const
+{
+	return Cast<APlayerCharacter>(GetOwner());
+}
+
+void UParryComponent::OnBossArm(APlayerCharacter* Target, int32 HitIndex, float WindowSec)
+{
+	APlayerCharacter* OwnerPC = GetOwnerPlayer();
+	if (!OwnerPC || OwnerPC != Target || WindowSec <= 0.f) return;
+
+	// Arm: 창 ON
+	bArmed = true;
+	ArmedHitIndex = HitIndex;
+	WindowEndTime = FPlatformTime::Seconds() + (double)WindowSec;
+
+	// 가장 가까운 보스 탐색 (TActorIterator → GetAllActorsOfClass 대체)
+	TArray<AActor*> Found;
+	UGameplayStatics::GetAllActorsOfClass(GetWorld(), ABoss_Sevarog::StaticClass(), Found);
+
+	float BestDist = TNumericLimits<float>::Max();
+	ABoss_Sevarog* Closest = nullptr;
+	for (AActor* A : Found)
+	{
+		if (ABoss_Sevarog* B = Cast<ABoss_Sevarog>(A))
+		{
+			const float Dist = FVector::Dist(B->GetActorLocation(), OwnerPC->GetActorLocation());
+			if (Dist < BestDist) { BestDist = Dist; Closest = B; }
+		}
+	}
+	ArmedBoss = Closest;
+
+	// 버퍼: 창 직전 입력 있었다면 즉시 성공
+	const double Now = FPlatformTime::Seconds();
+	if (!bLocked && (Now - LastPressTime) <= (double)BufferBeforeOpen)
+	{
+		HandleParrySuccess();
+		return;
+	}
+
+	// 창 만료 타이머
+	GetWorld()->GetTimerManager().ClearTimer(TimerExpire);
+	GetWorld()->GetTimerManager().SetTimer(TimerExpire, this, &UParryComponent::ExpireArm, WindowSec, false);
+}
+
+
+void UParryComponent::ExpireArm()
+{
+	bArmed = false;
+	ArmedHitIndex = -1;
+	ArmedBoss = nullptr;
+	WindowEndTime = 0.0;
+}
+
+void UParryComponent::OnParryPressed()
+{
+	const double Now = FPlatformTime::Seconds();
+	LastPressTime = Now;
+
+	// 모션은 항상 재생(성공/실패 공통 피드백)
+	PlayParryMontage();
+
+	// 리커버리 중이면 판정 불가
+	if (bLocked) return;
+
+	// 창 안이면 성공
+	if (bArmed && Now <= WindowEndTime)
+	{
+		HandleParrySuccess();
+		return;
+	}
+
+	// 실패 → 리커버리 진입
+	BeginRecovery();
+}
+
+void UParryComponent::HandleParrySuccess()
+{
+	APlayerCharacter* OwnerPC = GetOwnerPlayer();
+	if (!OwnerPC || !ArmedBoss.IsValid() || ArmedHitIndex < 0) { ExpireArm(); return; }
+
+	// AP +1 (최대 6)
+	OwnerPC->Stats.AP = FMath::Clamp(OwnerPC->Stats.AP + 1.f, 0.f, 6.f);
+
+	// 보스에 히트 성공 보고(모든 히트 성공 시 Ult+10은 보스가 처리)
+	ArmedBoss->NotifyParrySuccess(OwnerPC, ArmedHitIndex);
+
+	ExpireArm();
+}
+
+void UParryComponent::BeginRecovery()
+{
+	bLocked = true;
+	GetWorld()->GetTimerManager().ClearTimer(TimerRecovery);
+	GetWorld()->GetTimerManager().SetTimer(TimerRecovery, this, &UParryComponent::EndRecovery, RecoveryTime, false);
+}
+
+void UParryComponent::EndRecovery()
+{
+	bLocked = false;
+}
+
+void UParryComponent::PlayParryMontage() const
+{
+	if (!ParryMontage) return;
+	if (ACharacter* Ch = Cast<ACharacter>(GetOwner()))
+	{
+		if (UAnimInstance* Anim = Ch->GetMesh() ? Ch->GetMesh()->GetAnimInstance() : nullptr)
+		{
+			Anim->Montage_Play(ParryMontage, 1.0f);
+		}
+	}
+}

--- a/Source/CatheralBattle/Private/ParryComponent.h
+++ b/Source/CatheralBattle/Private/ParryComponent.h
@@ -1,28 +1,50 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-#pragma once
-
+﻿#pragma once
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "ParryComponent.generated.h"
 
+class ABoss_Sevarog;
+class APlayerCharacter;
+class UAnimMontage;
 
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
-class UParryComponent : public UActorComponent
+UCLASS(ClassGroup = (Combat), meta = (BlueprintSpawnableComponent))
+class CATHERALBATTLE_API UParryComponent : public UActorComponent
 {
 	GENERATED_BODY()
 
-public:	
-	// Sets default values for this component's properties
+public:
 	UParryComponent();
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parry") float RecoveryTime = 0.6f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parry") float BufferBeforeOpen = 0.10f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parry|Anim") UAnimMontage* ParryMontage = nullptr;
+
+	UFUNCTION(BlueprintCallable, Category = "Parry") void OnParryPressed();
+
 protected:
-	// Called when the game starts
 	virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+private:
+	// 상태
+	bool   bArmed = false;
+	bool   bLocked = false;
+	int32  ArmedHitIndex = -1;
+	double WindowEndTime = 0.0;
+	double LastPressTime = -100000.0;
 
-		
+	TWeakObjectPtr<ABoss_Sevarog> ArmedBoss;
+
+	FTimerHandle TimerExpire;
+	FTimerHandle TimerRecovery;
+	FTimerHandle TimerRebind;
+
+	// 내부
+	void TryBindBoss();
+	UFUNCTION() void OnBossArm(APlayerCharacter* Target, int32 HitIndex, float WindowSec);
+	void ExpireArm();
+	void BeginRecovery();
+	void EndRecovery();
+	void HandleParrySuccess();
+	void PlayParryMontage() const;
+	APlayerCharacter* GetOwnerPlayer() const;
 };

--- a/Source/CatheralBattle/Public/AN_BossHit.h
+++ b/Source/CatheralBattle/Public/AN_BossHit.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "AN_BossHit.generated.h"
+
+UCLASS()
+class CATHERALBATTLE_API UAN_BossHit : public UAnimNotify
+{
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite) int32 HitIndex = 0;
+    UPROPERTY(EditAnywhere, BlueprintReadWrite) float DamageMultiplier = 1.0f;
+
+    virtual void Notify(USkeletalMeshComponent* MeshComp,
+        UAnimSequenceBase* Animation,
+		const FAnimNotifyEventReference& EventReference) override;
+};

--- a/Source/CatheralBattle/Public/AN_PatternEnd.h
+++ b/Source/CatheralBattle/Public/AN_PatternEnd.h
@@ -1,0 +1,14 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "Animation/AnimNotifies/AnimNotify.h"
+#include "AN_PatternEnd.generated.h"
+
+UCLASS()
+class CATHERALBATTLE_API UAN_PatternEnd : public UAnimNotify
+{
+    GENERATED_BODY()
+public:
+    virtual void Notify(USkeletalMeshComponent* MeshComp,
+        UAnimSequenceBase* Animation,
+        const FAnimNotifyEventReference& EventReference) override;
+};

--- a/Source/CatheralBattle/Public/ParryInputProxy.h
+++ b/Source/CatheralBattle/Public/ParryInputProxy.h
@@ -1,26 +1,29 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-#pragma once
-
+﻿#pragma once
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "InputCoreTypes.h"
 #include "ParryInputProxy.generated.h"
+
+class UParryComponent;
 
 UCLASS()
 class CATHERALBATTLE_API AParryInputProxy : public AActor
 {
 	GENERATED_BODY()
-	
-public:	
-	// Sets default values for this actor's properties
+
+public:
 	AParryInputProxy();
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input") FKey PrimaryKey = EKeys::E;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Input") FKey SecondaryKey = EKeys::SpaceBar;
+
 protected:
-	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void Tick(float DeltaTime) override;
+private:
+	TWeakObjectPtr<UParryComponent> ParryComp;
 
+	void CacheParryComponent();
+	void BindKeys();
+	void OnParryPressed();
 };


### PR DESCRIPTION
주요 변경 사항:

신규 클래스 추가:

AN_ParryWindow: 패리 가능 구간을 정의하는 AnimNotifyState

AN_AttackHit: 공격 판정이 발생하는 시점을 알리는 AnimNotify

ANS_PatternLifecycle: 전체 패턴의 시작과 끝을 관리하는 AnimNotifyState

리팩토링:

Boss_Sevarog: 타이머 관련 로직을 모두 제거하고, 애니메이션 노티파이 이벤트를 수신하여 패턴을 처리하도록 수정

ParryComponent, ParryInputProxy: AN_ParryWindow와 연동하여 패리 가능 여부를 판단하도록 변경

BattleManager: 애니메이션 기반의 전투 흐름을 지원하도록 업데이트